### PR TITLE
Microgame/mask puzzle/review1

### DIFF
--- a/Assets/Resources/Microgames/MaskPuzzle/Prefabs.meta
+++ b/Assets/Resources/Microgames/MaskPuzzle/Prefabs.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d975febe4ec0a334ba3dbcd9fdd8ceab
+folderAsset: yes
+timeCreated: 1512198465
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Microgames/MaskPuzzle/Prefabs/Kitsune Mask.prefab
+++ b/Assets/Resources/Microgames/MaskPuzzle/Prefabs/Kitsune Mask.prefab
@@ -20,6 +20,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4731701024690010}
   - component: {fileID: 212713761859032200}
+  - component: {fileID: 114381941181458512}
   m_Layer: 0
   m_Name: Mask2Fragment3
   m_TagString: Untagged
@@ -36,6 +37,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4625352997579606}
   - component: {fileID: 212662377771849562}
+  - component: {fileID: 114040941143219904}
   m_Layer: 0
   m_Name: Mask2Fragment1
   m_TagString: Untagged
@@ -52,6 +54,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4652468109532446}
   - component: {fileID: 212975955650378620}
+  - component: {fileID: 114825532725832252}
   m_Layer: 0
   m_Name: Mask2Fragment4
   m_TagString: Untagged
@@ -68,6 +71,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4484300142051332}
   - component: {fileID: 212695375205222542}
+  - component: {fileID: 114427228296547778}
   m_Layer: 0
   m_Name: Mask2Fragment2
   m_TagString: Untagged
@@ -160,6 +164,18 @@ Transform:
   m_Father: {fileID: 4321061707562658}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114040941143219904
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1050508890848280}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fragmentsManager: {fileID: 0}
 --- !u!114 &114200805521757978
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -173,16 +189,52 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   overrideEdgeCheck: 0
   connectableEdges:
-  - fragment1: {fileID: 4625352997579606}
-    fragment2: {fileID: 4484300142051332}
-  - fragment1: {fileID: 4625352997579606}
-    fragment2: {fileID: 4731701024690010}
-  - fragment1: {fileID: 4625352997579606}
-    fragment2: {fileID: 4652468109532446}
-  - fragment1: {fileID: 4484300142051332}
-    fragment2: {fileID: 4652468109532446}
-  - fragment1: {fileID: 4731701024690010}
-    fragment2: {fileID: 4652468109532446}
+  - fragment1: {fileID: 114040941143219904}
+    fragment2: {fileID: 114427228296547778}
+  - fragment1: {fileID: 114040941143219904}
+    fragment2: {fileID: 114381941181458512}
+  - fragment1: {fileID: 114040941143219904}
+    fragment2: {fileID: 114825532725832252}
+  - fragment1: {fileID: 114427228296547778}
+    fragment2: {fileID: 114825532725832252}
+  - fragment1: {fileID: 114381941181458512}
+    fragment2: {fileID: 114825532725832252}
+--- !u!114 &114381941181458512
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1044125396063500}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fragmentsManager: {fileID: 0}
+--- !u!114 &114427228296547778
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1503243270866250}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fragmentsManager: {fileID: 0}
+--- !u!114 &114825532725832252
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1473924024156336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fragmentsManager: {fileID: 0}
 --- !u!212 &212662377771849562
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Resources/Microgames/MaskPuzzle/Prefabs/Kitsune Mask.prefab
+++ b/Assets/Resources/Microgames/MaskPuzzle/Prefabs/Kitsune Mask.prefab
@@ -1,0 +1,349 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1687458478200374}
+  m_IsPrefabParent: 1
+--- !u!1 &1044125396063500
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4731701024690010}
+  - component: {fileID: 212713761859032200}
+  m_Layer: 0
+  m_Name: Mask2Fragment3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1050508890848280
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4625352997579606}
+  - component: {fileID: 212662377771849562}
+  m_Layer: 0
+  m_Name: Mask2Fragment1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1473924024156336
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4652468109532446}
+  - component: {fileID: 212975955650378620}
+  m_Layer: 0
+  m_Name: Mask2Fragment4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1503243270866250
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4484300142051332}
+  - component: {fileID: 212695375205222542}
+  m_Layer: 0
+  m_Name: Mask2Fragment2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1687458478200374
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4321061707562658}
+  - component: {fileID: 114200805521757978}
+  m_Layer: 0
+  m_Name: Kitsune Mask
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4321061707562658
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1687458478200374}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4625352997579606}
+  - {fileID: 4484300142051332}
+  - {fileID: 4731701024690010}
+  - {fileID: 4652468109532446}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4484300142051332
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1503243270866250}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -4.97, y: 0.24, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4321061707562658}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4625352997579606
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1050508890848280}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.63, y: 2.99, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4321061707562658}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4652468109532446
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1473924024156336}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 5.5, y: 1.96, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4321061707562658}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4731701024690010
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1044125396063500}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.43, y: -3.69, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4321061707562658}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114200805521757978
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1687458478200374}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6eb2aa96d4225d4193e71305531a52f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  overrideEdgeCheck: 0
+  connectableEdges:
+  - fragment1: {fileID: 4625352997579606}
+    fragment2: {fileID: 4484300142051332}
+  - fragment1: {fileID: 4625352997579606}
+    fragment2: {fileID: 4731701024690010}
+  - fragment1: {fileID: 4625352997579606}
+    fragment2: {fileID: 4652468109532446}
+  - fragment1: {fileID: 4484300142051332}
+    fragment2: {fileID: 4652468109532446}
+  - fragment1: {fileID: 4731701024690010}
+    fragment2: {fileID: 4652468109532446}
+--- !u!212 &212662377771849562
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1050508890848280}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 45710c8f8106838498c211ff4f8d2868, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.4, y: 3.42}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+--- !u!212 &212695375205222542
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1503243270866250}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 8bffe88bd4cdbf24684276204ac55f5e, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.4, y: 3.42}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+--- !u!212 &212713761859032200
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1044125396063500}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: d0d722723aa4b55488367a857ac0b861, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.4, y: 3.42}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+--- !u!212 &212975955650378620
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1473924024156336}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 824e0520b940e7e489a1a4a65b2a3886, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.4, y: 3.42}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1

--- a/Assets/Resources/Microgames/MaskPuzzle/Prefabs/Kitsune Mask.prefab.meta
+++ b/Assets/Resources/Microgames/MaskPuzzle/Prefabs/Kitsune Mask.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 65a2cf07481bbc049a3f0f9d20c2f3b1
+timeCreated: 1512260391
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Microgames/MaskPuzzle/Prefabs/Oni Mask.prefab
+++ b/Assets/Resources/Microgames/MaskPuzzle/Prefabs/Oni Mask.prefab
@@ -36,6 +36,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4915271527016900}
   - component: {fileID: 212448834572869080}
+  - component: {fileID: 114935002067615486}
   m_Layer: 0
   m_Name: Mask1Fragment2
   m_TagString: Untagged
@@ -52,6 +53,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4002532601818598}
   - component: {fileID: 212463040415429376}
+  - component: {fileID: 114507511228539550}
   m_Layer: 0
   m_Name: Mask1Fragment3
   m_TagString: Untagged
@@ -68,6 +70,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4549492576177308}
   - component: {fileID: 212124899052274956}
+  - component: {fileID: 114662964352240116}
   m_Layer: 0
   m_Name: Mask1Fragment1
   m_TagString: Untagged
@@ -143,6 +146,42 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   overrideEdgeCheck: 1
   connectableEdges: []
+--- !u!114 &114507511228539550
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1514890584227592}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fragmentsManager: {fileID: 0}
+--- !u!114 &114662964352240116
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1632569659677796}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fragmentsManager: {fileID: 0}
+--- !u!114 &114935002067615486
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1252060377259540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fragmentsManager: {fileID: 0}
 --- !u!212 &212124899052274956
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Resources/Microgames/MaskPuzzle/Prefabs/Oni Mask.prefab
+++ b/Assets/Resources/Microgames/MaskPuzzle/Prefabs/Oni Mask.prefab
@@ -1,0 +1,268 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1162814963292266}
+  m_IsPrefabParent: 1
+--- !u!1 &1162814963292266
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4417257706893510}
+  - component: {fileID: 114374068601856804}
+  m_Layer: 0
+  m_Name: Oni Mask
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1252060377259540
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4915271527016900}
+  - component: {fileID: 212448834572869080}
+  m_Layer: 0
+  m_Name: Mask1Fragment2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1514890584227592
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4002532601818598}
+  - component: {fileID: 212463040415429376}
+  m_Layer: 0
+  m_Name: Mask1Fragment3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1632569659677796
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4549492576177308}
+  - component: {fileID: 212124899052274956}
+  m_Layer: 0
+  m_Name: Mask1Fragment1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4002532601818598
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1514890584227592}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -4.73, y: -3.19, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4417257706893510}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4417257706893510
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1162814963292266}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4549492576177308}
+  - {fileID: 4915271527016900}
+  - {fileID: 4002532601818598}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4549492576177308
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1632569659677796}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 5.57, y: -2.54, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4417257706893510}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4915271527016900
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1252060377259540}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -4.51, y: 3.79, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4417257706893510}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114374068601856804
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1162814963292266}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6eb2aa96d4225d4193e71305531a52f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  overrideEdgeCheck: 1
+  connectableEdges: []
+--- !u!212 &212124899052274956
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1632569659677796}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: baa42d1248403f7438beb5cc531a95a7, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.94, y: 4.7}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+--- !u!212 &212448834572869080
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1252060377259540}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 78f96e9ebff255840a00c032ff64c7f6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.94, y: 4.7}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+--- !u!212 &212463040415429376
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1514890584227592}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 4a2d18ec28767a347ad1f2d19cfcb984, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.94, y: 4.7}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1

--- a/Assets/Resources/Microgames/MaskPuzzle/Prefabs/Oni Mask.prefab.meta
+++ b/Assets/Resources/Microgames/MaskPuzzle/Prefabs/Oni Mask.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1cd59cffd1160584096daa0ed0c783e8
+timeCreated: 1512260367
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Microgames/MaskPuzzle/Scenes/MaskPuzzle1.unity
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scenes/MaskPuzzle1.unity
@@ -285,597 +285,59 @@ MonoBehaviour:
   victoryMoveSpeed: 0
   victoryRotationSpeed: 0
   fragments: []
---- !u!1 &100262352
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 100262353}
-  - component: {fileID: 100262354}
-  m_Layer: 0
-  m_Name: Mask2Fragment4
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &100262353
+  edges: {fileID: 0}
+--- !u!4 &192687541 stripped
 Transform:
+  m_PrefabParentObject: {fileID: 4417257706893510, guid: 1cd59cffd1160584096daa0ed0c783e8,
+    type: 2}
+  m_PrefabInternal: {fileID: 1750742137}
+--- !u!1001 &1083298469
+Prefab:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 100262352}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 5.5, y: 1.96, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1422574060}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &100262354
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 100262352}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 824e0520b940e7e489a1a4a65b2a3886, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 2.4, y: 3.42}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
---- !u!1 &192687540
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 192687541}
-  - component: {fileID: 192687542}
-  m_Layer: 0
-  m_Name: Oni Mask
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &192687541
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 25718909}
+    m_Modifications:
+    - target: {fileID: 4321061707562658, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321061707562658, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321061707562658, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321061707562658, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321061707562658, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321061707562658, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321061707562658, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4321061707562658, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1, type: 2}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1, type: 2}
+  m_IsPrefabParent: 0
+--- !u!4 &1422574060 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 192687540}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1567182570}
-  - {fileID: 560639940}
-  - {fileID: 949591444}
-  m_Father: {fileID: 25718909}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &192687542
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 192687540}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b6eb2aa96d4225d4193e71305531a52f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  overrideEdgeCheck: 1
-  connectableEdges: []
---- !u!1 &519521412
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 519521413}
-  - component: {fileID: 519521414}
-  m_Layer: 0
-  m_Name: Mask2Fragment1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &519521413
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 519521412}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.63, y: 2.99, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1422574060}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &519521414
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 519521412}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 45710c8f8106838498c211ff4f8d2868, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 2.4, y: 3.42}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
---- !u!1 &560639939
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 560639940}
-  - component: {fileID: 560639941}
-  m_Layer: 0
-  m_Name: Mask1Fragment2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &560639940
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 560639939}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -4.51, y: 3.79, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 192687541}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &560639941
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 560639939}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 78f96e9ebff255840a00c032ff64c7f6, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 2.94, y: 4.7}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
---- !u!1 &949591443
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 949591444}
-  - component: {fileID: 949591445}
-  m_Layer: 0
-  m_Name: Mask1Fragment3
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &949591444
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 949591443}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -4.73, y: -3.19, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 192687541}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &949591445
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 949591443}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 4a2d18ec28767a347ad1f2d19cfcb984, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 2.94, y: 4.7}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
---- !u!1 &1096009545
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1096009546}
-  - component: {fileID: 1096009547}
-  m_Layer: 0
-  m_Name: Mask2Fragment3
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1096009546
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1096009545}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.43, y: -3.69, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1422574060}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1096009547
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1096009545}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: d0d722723aa4b55488367a857ac0b861, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 2.4, y: 3.42}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
---- !u!1 &1422574059
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1422574060}
-  - component: {fileID: 1422574061}
-  m_Layer: 0
-  m_Name: Kitsune Mask
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1422574060
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1422574059}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 519521413}
-  - {fileID: 1547621616}
-  - {fileID: 1096009546}
-  - {fileID: 100262353}
-  m_Father: {fileID: 25718909}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1422574061
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1422574059}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b6eb2aa96d4225d4193e71305531a52f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  overrideEdgeCheck: 0
-  connectableEdges:
-  - fragment1: {fileID: 519521413}
-    fragment2: {fileID: 1547621616}
-  - fragment1: {fileID: 519521413}
-    fragment2: {fileID: 1096009546}
-  - fragment1: {fileID: 519521413}
-    fragment2: {fileID: 100262353}
-  - fragment1: {fileID: 1547621616}
-    fragment2: {fileID: 100262353}
-  - fragment1: {fileID: 1096009546}
-    fragment2: {fileID: 100262353}
---- !u!1 &1547621615
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1547621616}
-  - component: {fileID: 1547621617}
-  m_Layer: 0
-  m_Name: Mask2Fragment2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1547621616
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1547621615}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -4.97, y: 0.24, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1422574060}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1547621617
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1547621615}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 8bffe88bd4cdbf24684276204ac55f5e, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 2.4, y: 3.42}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
---- !u!1 &1567182569
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1567182570}
-  - component: {fileID: 1567182571}
-  m_Layer: 0
-  m_Name: Mask1Fragment1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1567182570
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1567182569}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 5.57, y: -2.54, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 192687541}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1567182571
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1567182569}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: baa42d1248403f7438beb5cc531a95a7, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 2.94, y: 4.7}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_PrefabParentObject: {fileID: 4321061707562658, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+    type: 2}
+  m_PrefabInternal: {fileID: 1083298469}
 --- !u!1001 &1692840176
 Prefab:
   m_ObjectHideFlags: 0
@@ -917,4 +379,46 @@ Prefab:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 72dba666113776b4dbc710553bb6dc53, type: 2}
+  m_IsPrefabParent: 0
+--- !u!1001 &1750742137
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 25718909}
+    m_Modifications:
+    - target: {fileID: 4417257706893510, guid: 1cd59cffd1160584096daa0ed0c783e8, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4417257706893510, guid: 1cd59cffd1160584096daa0ed0c783e8, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4417257706893510, guid: 1cd59cffd1160584096daa0ed0c783e8, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4417257706893510, guid: 1cd59cffd1160584096daa0ed0c783e8, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4417257706893510, guid: 1cd59cffd1160584096daa0ed0c783e8, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4417257706893510, guid: 1cd59cffd1160584096daa0ed0c783e8, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4417257706893510, guid: 1cd59cffd1160584096daa0ed0c783e8, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4417257706893510, guid: 1cd59cffd1160584096daa0ed0c783e8, type: 2}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 1cd59cffd1160584096daa0ed0c783e8, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/Resources/Microgames/MaskPuzzle/Scenes/MaskPuzzle1.unity
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scenes/MaskPuzzle1.unity
@@ -363,6 +363,7 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 192687541}
+  - component: {fileID: 192687542}
   m_Layer: 0
   m_Name: Oni Mask
   m_TagString: Untagged
@@ -386,6 +387,19 @@ Transform:
   m_Father: {fileID: 25718909}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &192687542
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 192687540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6eb2aa96d4225d4193e71305531a52f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  overrideEdgeCheck: 1
+  connectableEdges: []
 --- !u!1 &519521412
 GameObject:
   m_ObjectHideFlags: 0
@@ -674,6 +688,7 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 1422574060}
+  - component: {fileID: 1422574061}
   m_Layer: 0
   m_Name: Kitsune Mask
   m_TagString: Untagged
@@ -698,6 +713,29 @@ Transform:
   m_Father: {fileID: 25718909}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1422574061
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1422574059}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6eb2aa96d4225d4193e71305531a52f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  overrideEdgeCheck: 0
+  connectableEdges:
+  - fragment1: {fileID: 519521413}
+    fragment2: {fileID: 1547621616}
+  - fragment1: {fileID: 519521413}
+    fragment2: {fileID: 1096009546}
+  - fragment1: {fileID: 519521413}
+    fragment2: {fileID: 100262353}
+  - fragment1: {fileID: 1547621616}
+    fragment2: {fileID: 100262353}
+  - fragment1: {fileID: 1096009546}
+    fragment2: {fileID: 100262353}
 --- !u!1 &1547621615
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Microgames/MaskPuzzle/Scenes/MaskPuzzle1.unity
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scenes/MaskPuzzle1.unity
@@ -291,6 +291,57 @@ Transform:
   m_PrefabParentObject: {fileID: 4417257706893510, guid: 1cd59cffd1160584096daa0ed0c783e8,
     type: 2}
   m_PrefabInternal: {fileID: 1750742137}
+--- !u!1 &598229887 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1632569659677796, guid: 1cd59cffd1160584096daa0ed0c783e8,
+    type: 2}
+  m_PrefabInternal: {fileID: 1750742137}
+--- !u!114 &598229888
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 598229887}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fragmentsManager: {fileID: 0}
+--- !u!1 &695981570 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1044125396063500, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+    type: 2}
+  m_PrefabInternal: {fileID: 1083298469}
+--- !u!114 &695981571
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 695981570}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fragmentsManager: {fileID: 0}
+--- !u!1 &715457448 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1514890584227592, guid: 1cd59cffd1160584096daa0ed0c783e8,
+    type: 2}
+  m_PrefabInternal: {fileID: 1750742137}
+--- !u!114 &715457449
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 715457448}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fragmentsManager: {fileID: 0}
 --- !u!1001 &1083298469
 Prefab:
   m_ObjectHideFlags: 0
@@ -330,6 +381,56 @@ Prefab:
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+        type: 2}
+      propertyPath: connectableEdges.Array.data[0].fragment1
+      value: 
+      objectReference: {fileID: 1613229425}
+    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+        type: 2}
+      propertyPath: connectableEdges.Array.data[0].fragment2
+      value: 
+      objectReference: {fileID: 1565614891}
+    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+        type: 2}
+      propertyPath: connectableEdges.Array.data[1].fragment1
+      value: 
+      objectReference: {fileID: 1613229425}
+    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+        type: 2}
+      propertyPath: connectableEdges.Array.data[1].fragment2
+      value: 
+      objectReference: {fileID: 695981571}
+    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+        type: 2}
+      propertyPath: connectableEdges.Array.data[2].fragment1
+      value: 
+      objectReference: {fileID: 1613229425}
+    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+        type: 2}
+      propertyPath: connectableEdges.Array.data[2].fragment2
+      value: 
+      objectReference: {fileID: 1430067149}
+    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+        type: 2}
+      propertyPath: connectableEdges.Array.data[3].fragment1
+      value: 
+      objectReference: {fileID: 1565614891}
+    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+        type: 2}
+      propertyPath: connectableEdges.Array.data[3].fragment2
+      value: 
+      objectReference: {fileID: 1430067149}
+    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+        type: 2}
+      propertyPath: connectableEdges.Array.data[4].fragment1
+      value: 
+      objectReference: {fileID: 695981571}
+    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+        type: 2}
+      propertyPath: connectableEdges.Array.data[4].fragment2
+      value: 
+      objectReference: {fileID: 1430067149}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1, type: 2}
   m_IsPrefabParent: 0
@@ -338,6 +439,57 @@ Transform:
   m_PrefabParentObject: {fileID: 4321061707562658, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
     type: 2}
   m_PrefabInternal: {fileID: 1083298469}
+--- !u!1 &1430067148 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1473924024156336, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+    type: 2}
+  m_PrefabInternal: {fileID: 1083298469}
+--- !u!114 &1430067149
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1430067148}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fragmentsManager: {fileID: 0}
+--- !u!1 &1565614890 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1503243270866250, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+    type: 2}
+  m_PrefabInternal: {fileID: 1083298469}
+--- !u!114 &1565614891
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1565614890}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fragmentsManager: {fileID: 0}
+--- !u!1 &1613229424 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1050508890848280, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
+    type: 2}
+  m_PrefabInternal: {fileID: 1083298469}
+--- !u!114 &1613229425
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1613229424}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fragmentsManager: {fileID: 0}
 --- !u!1001 &1692840176
 Prefab:
   m_ObjectHideFlags: 0
@@ -422,3 +574,20 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 1cd59cffd1160584096daa0ed0c783e8, type: 2}
   m_IsPrefabParent: 0
+--- !u!1 &2084273637 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1252060377259540, guid: 1cd59cffd1160584096daa0ed0c783e8,
+    type: 2}
+  m_PrefabInternal: {fileID: 1750742137}
+--- !u!114 &2084273638
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2084273637}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fragmentsManager: {fileID: 0}

--- a/Assets/Resources/Microgames/MaskPuzzle/Scenes/MaskPuzzle1.unity
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scenes/MaskPuzzle1.unity
@@ -122,7 +122,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &25718909
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Microgames/MaskPuzzle/Scenes/MaskPuzzle1.unity
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scenes/MaskPuzzle1.unity
@@ -291,57 +291,6 @@ Transform:
   m_PrefabParentObject: {fileID: 4417257706893510, guid: 1cd59cffd1160584096daa0ed0c783e8,
     type: 2}
   m_PrefabInternal: {fileID: 1750742137}
---- !u!1 &598229887 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1632569659677796, guid: 1cd59cffd1160584096daa0ed0c783e8,
-    type: 2}
-  m_PrefabInternal: {fileID: 1750742137}
---- !u!114 &598229888
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 598229887}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  fragmentsManager: {fileID: 0}
---- !u!1 &695981570 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1044125396063500, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
-    type: 2}
-  m_PrefabInternal: {fileID: 1083298469}
---- !u!114 &695981571
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 695981570}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  fragmentsManager: {fileID: 0}
---- !u!1 &715457448 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1514890584227592, guid: 1cd59cffd1160584096daa0ed0c783e8,
-    type: 2}
-  m_PrefabInternal: {fileID: 1750742137}
---- !u!114 &715457449
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 715457448}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  fragmentsManager: {fileID: 0}
 --- !u!1001 &1083298469
 Prefab:
   m_ObjectHideFlags: 0
@@ -381,56 +330,6 @@ Prefab:
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
-        type: 2}
-      propertyPath: connectableEdges.Array.data[0].fragment1
-      value: 
-      objectReference: {fileID: 1613229425}
-    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
-        type: 2}
-      propertyPath: connectableEdges.Array.data[0].fragment2
-      value: 
-      objectReference: {fileID: 1565614891}
-    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
-        type: 2}
-      propertyPath: connectableEdges.Array.data[1].fragment1
-      value: 
-      objectReference: {fileID: 1613229425}
-    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
-        type: 2}
-      propertyPath: connectableEdges.Array.data[1].fragment2
-      value: 
-      objectReference: {fileID: 695981571}
-    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
-        type: 2}
-      propertyPath: connectableEdges.Array.data[2].fragment1
-      value: 
-      objectReference: {fileID: 1613229425}
-    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
-        type: 2}
-      propertyPath: connectableEdges.Array.data[2].fragment2
-      value: 
-      objectReference: {fileID: 1430067149}
-    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
-        type: 2}
-      propertyPath: connectableEdges.Array.data[3].fragment1
-      value: 
-      objectReference: {fileID: 1565614891}
-    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
-        type: 2}
-      propertyPath: connectableEdges.Array.data[3].fragment2
-      value: 
-      objectReference: {fileID: 1430067149}
-    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
-        type: 2}
-      propertyPath: connectableEdges.Array.data[4].fragment1
-      value: 
-      objectReference: {fileID: 695981571}
-    - target: {fileID: 114200805521757978, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
-        type: 2}
-      propertyPath: connectableEdges.Array.data[4].fragment2
-      value: 
-      objectReference: {fileID: 1430067149}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1, type: 2}
   m_IsPrefabParent: 0
@@ -439,57 +338,6 @@ Transform:
   m_PrefabParentObject: {fileID: 4321061707562658, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
     type: 2}
   m_PrefabInternal: {fileID: 1083298469}
---- !u!1 &1430067148 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1473924024156336, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
-    type: 2}
-  m_PrefabInternal: {fileID: 1083298469}
---- !u!114 &1430067149
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1430067148}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  fragmentsManager: {fileID: 0}
---- !u!1 &1565614890 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1503243270866250, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
-    type: 2}
-  m_PrefabInternal: {fileID: 1083298469}
---- !u!114 &1565614891
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1565614890}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  fragmentsManager: {fileID: 0}
---- !u!1 &1613229424 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1050508890848280, guid: 65a2cf07481bbc049a3f0f9d20c2f3b1,
-    type: 2}
-  m_PrefabInternal: {fileID: 1083298469}
---- !u!114 &1613229425
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1613229424}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  fragmentsManager: {fileID: 0}
 --- !u!1001 &1692840176
 Prefab:
   m_ObjectHideFlags: 0
@@ -574,20 +422,3 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 1cd59cffd1160584096daa0ed0c783e8, type: 2}
   m_IsPrefabParent: 0
---- !u!1 &2084273637 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1252060377259540, guid: 1cd59cffd1160584096daa0ed0c783e8,
-    type: 2}
-  m_PrefabInternal: {fileID: 1750742137}
---- !u!114 &2084273638
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2084273637}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c4562e7059b5c8e49b8c20c36a15d5cd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  fragmentsManager: {fileID: 0}

--- a/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleGrabbableFragmentsManager.cs
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleGrabbableFragmentsManager.cs
@@ -62,8 +62,5 @@ public class MaskPuzzleGrabbableFragmentsManager : MonoBehaviour {
             // Add the fragment to list
             fragments.Add(currentFragment);
         }
-
-        // Disable the mask library - we won't need the other masks
-        maskLibrary.SetActive(false);
 	}
 }

--- a/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleGrabbableFragmentsManager.cs
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleGrabbableFragmentsManager.cs
@@ -23,7 +23,7 @@ public class MaskPuzzleGrabbableFragmentsManager : MonoBehaviour {
 
     public float victoryMoveSpeed, victoryRotationSpeed;
 
-    public List<GameObject> fragments;
+    public List<MaskPuzzleMaskFragment> fragments;
     public MaskPuzzleMaskEdges edges;
 
     // Initialization - choose and prepare the mask that will be assembled by the player
@@ -46,7 +46,7 @@ public class MaskPuzzleGrabbableFragmentsManager : MonoBehaviour {
             currentFragment.transform.parent = transform;
 
             // Add script to the fragment
-            currentFragment.AddComponent<MaskPuzzleMaskFragment>();
+            //currentFragment.AddComponent<MaskPuzzleMaskFragment>();
             currentFragment.GetComponent<MaskPuzzleMaskFragment>().fragmentsManager = this;
 
             // Setup drag and drop
@@ -64,7 +64,7 @@ public class MaskPuzzleGrabbableFragmentsManager : MonoBehaviour {
             currentFragment.GetComponent<MouseGrabbable>().onRelease = releaseEvent;
 
             // Add the fragment to list
-            fragments.Add(currentFragment);
+            fragments.Add(currentFragment.GetComponent<MaskPuzzleMaskFragment>());
         }
 	}
 }

--- a/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleGrabbableFragmentsManager.cs
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleGrabbableFragmentsManager.cs
@@ -24,6 +24,7 @@ public class MaskPuzzleGrabbableFragmentsManager : MonoBehaviour {
     public float victoryMoveSpeed, victoryRotationSpeed;
 
     public List<GameObject> fragments;
+    public MaskPuzzleMaskEdges edges;
 
     // Initialization - choose and prepare the mask that will be assembled by the player
     void Start ()
@@ -31,6 +32,9 @@ public class MaskPuzzleGrabbableFragmentsManager : MonoBehaviour {
         // Choose a random mask from the library
         GameObject chosenMask = maskLibrary.transform.GetChild(Random.Range(0, maskLibrary.transform.childCount)).gameObject;
         print("Chosen " + chosenMask.name + ". It has " + chosenMask.transform.childCount + " fragments.");
+
+        // Get info about the edges that should be connected
+        edges = chosenMask.GetComponent<MaskPuzzleMaskEdges>();
 
         // Initialize all fragments of the chosen mask
         while (chosenMask.transform.childCount > 0)

--- a/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskEdges.cs
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskEdges.cs
@@ -13,12 +13,12 @@ public class MaskPuzzleMaskEdges : MonoBehaviour
     [System.Serializable]
     public class Edge
     {
-        public Transform fragment1;
-        public Transform fragment2;
+        public MaskPuzzleMaskFragment fragment1;
+        public MaskPuzzleMaskFragment fragment2;
     }
 
     // Check if two fragments can be connected directly
-    public bool areConnectable(Transform fragment1, Transform fragment2)
+    public bool areConnectable(MaskPuzzleMaskFragment fragment1, MaskPuzzleMaskFragment fragment2)
     {
         if (overrideEdgeCheck)
             return true;
@@ -34,11 +34,11 @@ public class MaskPuzzleMaskEdges : MonoBehaviour
     }
 
     // Check if any fragment from the first group can be connected to any fragment from the second group
-    public bool areConnectable(List<GameObject> fragmentGroup1, List<GameObject> fragmentGroup2)
+    public bool areConnectable(List<MaskPuzzleMaskFragment> fragmentGroup1, List<MaskPuzzleMaskFragment> fragmentGroup2)
     {
-        foreach (GameObject fragment1 in fragmentGroup1)
-            foreach (GameObject fragment2 in fragmentGroup2)
-                if (areConnectable(fragment1.transform, fragment2.transform))
+        foreach (MaskPuzzleMaskFragment fragment1 in fragmentGroup1)
+            foreach (MaskPuzzleMaskFragment fragment2 in fragmentGroup2)
+                if (areConnectable(fragment1, fragment2))
                     return true;
 
         return false;

--- a/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskEdges.cs
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskEdges.cs
@@ -16,4 +16,19 @@ public class MaskPuzzleMaskEdges : MonoBehaviour
         public Transform fragment1;
         public Transform fragment2;
     }
+
+    public bool areConnectable(Transform fragment1, Transform fragment2)
+    {
+        if (overrideEdgeCheck)
+            return true;
+        foreach (Edge edge in connectableEdges)
+        {
+            if ((fragment1 == edge.fragment1 && fragment2 == edge.fragment2) ||
+                (fragment1 == edge.fragment2 && fragment2 == edge.fragment1))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskEdges.cs
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskEdges.cs
@@ -17,6 +17,7 @@ public class MaskPuzzleMaskEdges : MonoBehaviour
         public Transform fragment2;
     }
 
+    // Check if two fragments can be connected directly
     public bool areConnectable(Transform fragment1, Transform fragment2)
     {
         if (overrideEdgeCheck)
@@ -29,6 +30,17 @@ public class MaskPuzzleMaskEdges : MonoBehaviour
                 return true;
             }
         }
+        return false;
+    }
+
+    // Check if any fragment from the first group can be connected to any fragment from the second group
+    public bool areConnectable(List<GameObject> fragmentGroup1, List<GameObject> fragmentGroup2)
+    {
+        foreach (GameObject fragment1 in fragmentGroup1)
+            foreach (GameObject fragment2 in fragmentGroup2)
+                if (areConnectable(fragment1.transform, fragment2.transform))
+                    return true;
+
         return false;
     }
 }

--- a/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskEdges.cs
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskEdges.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MaskPuzzleMaskEdges : MonoBehaviour
+{
+    [Header("Ignore the edges and always allow two mask pieces to connect")]
+    public bool overrideEdgeCheck = true;
+
+    [Header("All possible edges that can connect with one-another")]
+    public Edge[] connectableEdges;
+
+    [System.Serializable]
+    public class Edge
+    {
+        public Transform fragment1;
+        public Transform fragment2;
+    }
+}

--- a/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskEdges.cs.meta
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskEdges.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b6eb2aa96d4225d4193e71305531a52f
+timeCreated: 1512080958
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskFragment.cs
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskFragment.cs
@@ -10,6 +10,7 @@ public class MaskPuzzleMaskFragment : MonoBehaviour {
     public void OnGrab()
     {
         SwapParents();
+        MoveChildrenToFront();
     }
 
     public void OnRelease()
@@ -43,8 +44,6 @@ public class MaskPuzzleMaskFragment : MonoBehaviour {
     // Checks whether this mask is a child of another mask
     // If yes, it reverses the relationship so it becomes the other mask's parent instead
     // This is done to ensure that both linked masks are moved together regardless of which one is grabbed
-    // FIXME: Children aren't brought up to the front layer when grabbing the group (only the parent is),
-    //        so they can be behind other fragments while being moved around
     void SwapParents()
     {
         if (transform.parent != fragmentsManager.transform)
@@ -52,6 +51,19 @@ public class MaskPuzzleMaskFragment : MonoBehaviour {
             Transform otherMask = transform.parent;
             transform.parent = fragmentsManager.transform;
             otherMask.parent = transform;
+        }
+    }
+
+    // To be called when grabbing a mask, after SwapParents()
+    // The grabbed fragment is brought up to the front layer automatically by MouseGrabbableGroup,
+    // but the other linked fragments need to be brought to the front manually - this method does this
+    void MoveChildrenToFront()
+    {
+        Transform[] children = GetComponentsInChildren<Transform>();
+        foreach (Transform child in children)
+        {
+            print("MoveChildrenToFront(): " + child.gameObject + " moved to the front.");
+            fragmentsManager.GetComponent<MouseGrabbableGroup>().moveToFront(child.gameObject.GetComponent<MouseGrabbable>());
         }
     }
 

--- a/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskFragment.cs
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskFragment.cs
@@ -29,13 +29,22 @@ public class MaskPuzzleMaskFragment : MonoBehaviour {
         {
             if (fragmentsManager.fragments[i] == this)
                 continue;
-            if (Vector2.Distance(transform.position, fragmentsManager.fragments[i].transform.position)
-                <= fragmentsManager.maxSnapDistance)
+
+            Transform[] children = GetComponentsInChildren<Transform>();
+            foreach (Transform child in children)
             {
-                transform.position = (Vector2)fragmentsManager.fragments[i].transform.position;
-                transform.parent = fragmentsManager.transform;
-                fragmentsManager.fragments[i].transform.parent = transform;
-                print("Snapped " + name + " to " + fragmentsManager.fragments[i].name + " and became its parent");
+                if (fragmentsManager.edges.areConnectable(child.transform, fragmentsManager.fragments[i].transform))
+                {
+                    if (Vector2.Distance(transform.position, fragmentsManager.fragments[i].transform.position)
+                        <= fragmentsManager.maxSnapDistance)
+                    {
+                        transform.position = (Vector2)fragmentsManager.fragments[i].transform.position;
+                        transform.parent = fragmentsManager.transform;
+                        fragmentsManager.fragments[i].transform.parent = transform;
+                        print("Snapped " + name + " to " + fragmentsManager.fragments[i].name + " and became its parent");
+                    }
+                    break;
+                }
             }
         }
     }

--- a/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskFragment.cs
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskFragment.cs
@@ -30,19 +30,21 @@ public class MaskPuzzleMaskFragment : MonoBehaviour {
             if (fragmentsManager.fragments[i] == this)
                 continue;
 
+            // Check distance
+            if (Vector2.Distance(transform.position, fragmentsManager.fragments[i].transform.position)
+                > fragmentsManager.maxSnapDistance)
+                continue;
+
+            // Check if the grabbed fragment or any of its children can be connected to the i-th fragment
             Transform[] children = GetComponentsInChildren<Transform>();
             foreach (Transform child in children)
             {
                 if (fragmentsManager.edges.areConnectable(child.transform, fragmentsManager.fragments[i].transform))
                 {
-                    if (Vector2.Distance(transform.position, fragmentsManager.fragments[i].transform.position)
-                        <= fragmentsManager.maxSnapDistance)
-                    {
-                        transform.position = (Vector2)fragmentsManager.fragments[i].transform.position;
-                        transform.parent = fragmentsManager.transform;
-                        fragmentsManager.fragments[i].transform.parent = transform;
-                        print("Snapped " + name + " to " + fragmentsManager.fragments[i].name + " and became its parent");
-                    }
+                    transform.position = (Vector2)fragmentsManager.fragments[i].transform.position;
+                    transform.parent = fragmentsManager.transform;
+                    fragmentsManager.fragments[i].transform.parent = transform;
+                    print("Snapped " + name + " to " + fragmentsManager.fragments[i].name + " and became its parent");
                     break;
                 }
             }

--- a/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskFragment.cs
+++ b/Assets/Resources/Microgames/MaskPuzzle/Scripts/MaskPuzzleMaskFragment.cs
@@ -8,6 +8,37 @@ public class MaskPuzzleMaskFragment : MonoBehaviour {
 
     public List<GameObject> connectedTo = new List<GameObject>();
 
+    public FragmentGroup fragmentGroup;
+
+    //Class to keep track of which fragments are connected and determine a fragment's group in constant time
+    public class FragmentGroup
+    {
+        public List<MaskPuzzleMaskFragment> fragments;
+
+        public FragmentGroup()
+        {
+            fragments = new List<MaskPuzzleMaskFragment>();
+        }
+
+        //Connect this group to another fragment group
+        public void connectTo(FragmentGroup group)
+        {
+            if (group == this)
+                return;
+
+            fragments.AddRange(group.fragments);
+            foreach (var fragment in group.fragments)
+            {
+                fragment.fragmentGroup = this;
+            }
+        }
+    }
+
+    void Start()
+    {
+        fragmentGroup = new FragmentGroup();
+    }
+
     // Callbacks for drag and drop events
     public void OnGrab()
     {

--- a/Assets/Resources/Microgames/MaskPuzzle/Traits1.prefab
+++ b/Assets/Resources/Microgames/MaskPuzzle/Traits1.prefab
@@ -53,7 +53,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _controlScheme: 1
   _hideCursor: 0
-  _duration: 0
+  _duration: 1
   _canEndEarly: 0
   _command: Assemble!
   _defaultVictory: 0

--- a/Assets/Resources/Microgames/MaskPuzzle/Traits2.prefab
+++ b/Assets/Resources/Microgames/MaskPuzzle/Traits2.prefab
@@ -53,7 +53,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _controlScheme: 1
   _hideCursor: 0
-  _duration: 0
+  _duration: 1
   _canEndEarly: 0
   _command: Assemble!
   _defaultVictory: 0

--- a/Assets/Resources/Microgames/MaskPuzzle/Traits3.prefab
+++ b/Assets/Resources/Microgames/MaskPuzzle/Traits3.prefab
@@ -53,7 +53,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _controlScheme: 1
   _hideCursor: 0
-  _duration: 0
+  _duration: 1
   _canEndEarly: 0
   _command: Assemble!
   _defaultVictory: 0


### PR DESCRIPTION
https://workflowy.com/s/E_M2.Xg068t3nv8
- Duration changed to 16 beats.
- Unused masks start disabled and only the one chosen to be assembled gets enabled.
- All fragments connected to the grabbed fragment are now correctly brought to the front of other fragments.
- It is now possible to specify which fragments can be connected to each other directly. If the override option is checked (it is by default) every fragment can be connected to every other fragment and there's no need to specify them manually. This is configured per mask.
- Each mask is now a prefab.